### PR TITLE
Merge changes from my development repo (#45)

### DIFF
--- a/OpenKJ/OpenKJ.pro
+++ b/OpenKJ/OpenKJ.pro
@@ -8,6 +8,7 @@ QT += core gui sql network widgets multimedia concurrent svg printsupport
 
 unix: DEFINES += USE_GL
 
+
 win32: RC_ICONS = Icons/okjicon.ico
 
 contains(DEFINES, USE_GL) {
@@ -56,6 +57,8 @@ DEFINES += GIT_VERSION=\\"\"$$VERSION\\"\"
 QMAKE_TARGET_COMPANY = OpenKJ.org
 QMAKE_TARGET_PRODUCT = OpenKJ
 QMAKE_TARGET_DESCRIPTION = OpenKJ karaoke hosting software
+DEFINES += OKJ_UNSTABLE
+
 
 unix: BLDDATE = $$system(date -R)
 win32: BLDDATE = $$system(date /t)
@@ -213,7 +216,9 @@ SOURCES += main.cpp\
     taglib/tagutils.cpp \
     dlgbookcreator.cpp \
     dlgeq.cpp \
-    audiofader.cpp
+    audiofader.cpp \
+    customlineedit.cpp \
+    updatechecker.cpp
 
 HEADERS  += mainwindow.h \
     libCDG/include/libCDG.h \
@@ -375,7 +380,9 @@ HEADERS  += mainwindow.h \
     taglib/tagutils.h \
     dlgbookcreator.h \
     dlgeq.h \
-    audiofader.h
+    audiofader.h \
+    customlineedit.h \
+    updatechecker.h
 
 FORMS    += mainwindow.ui \
     dlgkeychange.ui \

--- a/OpenKJ/customlineedit.cpp
+++ b/OpenKJ/customlineedit.cpp
@@ -1,0 +1,19 @@
+#include "customlineedit.h"
+#include <QKeyEvent>
+
+CustomLineEdit::CustomLineEdit(QWidget *parent) : QLineEdit(parent)
+{
+}
+
+
+void CustomLineEdit::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Escape)
+    {
+        emit escapePressed();
+    }
+    else
+    {
+        QLineEdit::keyPressEvent(event);
+    }
+}

--- a/OpenKJ/customlineedit.h
+++ b/OpenKJ/customlineedit.h
@@ -1,0 +1,18 @@
+#ifndef CUSTOMLINEEDIT_H
+#define CUSTOMLINEEDIT_H
+#include <QLineEdit>
+
+class CustomLineEdit : public QLineEdit
+{
+    Q_OBJECT
+public:
+    CustomLineEdit(QWidget *parent);
+
+    // QWidget interface
+protected:
+    void keyPressEvent(QKeyEvent *event);
+signals:
+    void escapePressed();
+};
+
+#endif // CUSTOMLINEEDIT_H

--- a/OpenKJ/dlgrequests.cpp
+++ b/OpenKJ/dlgrequests.cpp
@@ -69,6 +69,7 @@ DlgRequests::DlgRequests(RotationModel *rotationModel, QWidget *parent) :
     ui->tableViewSearch->hideColumn(6);
     ui->tableViewSearch->horizontalHeader()->resizeSection(4,75);
     connect(songbookApi, SIGNAL(venuesChanged(OkjsVenues)), this, SLOT(venuesChanged(OkjsVenues)));
+    connect(ui->lineEditSearch, SIGNAL(escapePressed()), this, SLOT(lineEditSearchEscapePressed()));
 }
 
 DlgRequests::~DlgRequests()
@@ -343,4 +344,13 @@ void DlgRequests::on_lineEditSearch_textChanged(const QString &arg1)
         dbModel->search(arg1);
         lastVal = arg1.trimmed();
     }
+}
+
+void DlgRequests::lineEditSearchEscapePressed()
+{
+    QModelIndex index;
+    index = ui->treeViewRequests->selectionModel()->selectedIndexes().at(0);
+    QString filterStr = index.sibling(index.row(),2).data().toString() + " " + index.sibling(index.row(),3).data().toString();
+    dbModel->search(filterStr);
+    ui->lineEditSearch->setText(filterStr);
 }

--- a/OpenKJ/dlgrequests.h
+++ b/OpenKJ/dlgrequests.h
@@ -76,6 +76,7 @@ private slots:
     void on_comboBoxVenue_activated(int index);
     void previewCdg();
     void on_lineEditSearch_textChanged(const QString &arg1);
+    void lineEditSearchEscapePressed();
 };
 
 #endif // KHREQUESTSDIALOG_H

--- a/OpenKJ/dlgrequests.ui
+++ b/OpenKJ/dlgrequests.ui
@@ -179,7 +179,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEditSearch"/>
+         <widget class="CustomLineEdit" name="lineEditSearch"/>
         </item>
         <item>
          <widget class="QPushButton" name="pushButtonSearch">
@@ -483,6 +483,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>customlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="resources.qrc"/>
  </resources>

--- a/OpenKJ/mainwindow.cpp
+++ b/OpenKJ/mainwindow.cpp
@@ -38,6 +38,7 @@
 #include <QSvgRenderer>
 #include "audiorecorder.h"
 #include "okjsongbookapi.h"
+#include "updatechecker.h"
 
 Settings *settings;
 OKJSongbookAPI *songbookApi;
@@ -420,6 +421,13 @@ MainWindow::MainWindow(QWidget *parent) :
     bmAudioBackend->setEqLevel8(settings->eqBLevel8());
     bmAudioBackend->setEqLevel9(settings->eqBLevel9());
     bmAudioBackend->setEqLevel10(settings->eqBLevel10());
+    connect(ui->lineEdit, SIGNAL(escapePressed()), ui->lineEdit, SLOT(clear()));
+    connect(ui->lineEditBmSearch, SIGNAL(escapePressed()), ui->lineEditBmSearch, SLOT(clear()));
+    connect(qModel, SIGNAL(songDroppedWithoutSinger()), this, SLOT(songDropNoSingerSel()));
+
+    checker = new UpdateChecker(this);
+    connect(checker, SIGNAL(newVersionAvailable(QString)), this, SLOT(newVersionAvailable(QString)));
+    checker->checkForUpdates();
 
     qWarning() << "Initial UI stup complete";
 }
@@ -1987,4 +1995,32 @@ void MainWindow::on_sliderVolume_sliderMoved(int position)
 void MainWindow::on_sliderBmVolume_sliderMoved(int position)
 {
     bmAudioBackend->setVolume(position);
+}
+
+void MainWindow::songDropNoSingerSel()
+{
+    QMessageBox msgBox;
+    msgBox.setText("No singer selected.  You must select a singer before you can add songs to a queue.");
+    msgBox.exec();
+}
+
+void MainWindow::newVersionAvailable(QString version)
+{
+    QMessageBox msgBox;
+    msgBox.setTextFormat(Qt::RichText);
+    msgBox.setText("New version of OpenKJ is available: " + version);
+    msgBox.setIcon(QMessageBox::Information);
+    if (checker->getOS() == "Linux")
+    {
+        msgBox.setInformativeText("To install the update, please use your distribution's package manager.");
+    }
+    if (checker->getOS() == "Linux" || checker->getOS() == "Win64")
+    {
+        msgBox.setInformativeText("You can download the new version at <a href=https://openkj.org/windows_downloads>https://openkj.org/windows_downloads</a>");
+    }
+    if (checker->getOS() == "MacOS")
+    {
+        msgBox.setInformativeText("You can download the new version at <a href=https://openkj.org/macos_downloads>https://openkj.org/macos_downloads</a>");
+    }
+    msgBox.exec();
 }

--- a/OpenKJ/mainwindow.h
+++ b/OpenKJ/mainwindow.h
@@ -22,6 +22,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include "customlineedit.h"
 #include <QtSql>
 #include "libCDG/include/libCDG.h"
 #include <QSortFilterProxyModel>
@@ -58,6 +59,7 @@
 #include "audiorecorder.h"
 #include "dlgbookcreator.h"
 #include "dlgeq.h"
+#include "updatechecker.h"
 
 using namespace std;
 
@@ -129,6 +131,7 @@ private:
     AbstractAudioBackend::State m_lastAudioState;
     void refreshSongDbCache();
     QTimer *karaokeAATimer;
+    UpdateChecker *checker;
 
 public:
     explicit MainWindow(QWidget *parent = 0);
@@ -229,6 +232,8 @@ private slots:
     void on_sliderVolume_sliderMoved(int position);
 
     void on_sliderBmVolume_sliderMoved(int position);
+    void songDropNoSingerSel();
+    void newVersionAvailable(QString version);
 
 protected:
     void closeEvent(QCloseEvent *event);

--- a/OpenKJ/mainwindow.ui
+++ b/OpenKJ/mainwindow.ui
@@ -162,7 +162,7 @@
                   <number>4</number>
                  </property>
                  <item>
-                  <widget class="QLineEdit" name="lineEdit"/>
+                  <widget class="CustomLineEdit" name="lineEdit"/>
                  </item>
                  <item>
                   <widget class="QPushButton" name="pushButton">
@@ -2430,7 +2430,7 @@
                    <number>2</number>
                   </property>
                   <item>
-                   <widget class="QLineEdit" name="lineEditBmSearch"/>
+                   <widget class="CustomLineEdit" name="lineEditBmSearch"/>
                   </item>
                   <item>
                    <widget class="QPushButton" name="buttonBmSearch">
@@ -2833,6 +2833,11 @@
    <extends>QWidget</extends>
    <header>cdgvideowidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>CustomLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>customlineedit.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/OpenKJ/queuemodel.cpp
+++ b/OpenKJ/queuemodel.cpp
@@ -167,6 +167,12 @@ bool QueueModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int 
     Q_UNUSED(action);
     Q_UNUSED(column);
 
+    if (singer() == -1)
+    {
+        qWarning() << "Song dropped into queue w/ no singer selected";
+        emit songDroppedWithoutSinger();
+        return false;
+    }
     if (data->hasFormat("integer/queuepos"))
     {
         int droprow;

--- a/OpenKJ/queuemodel.h
+++ b/OpenKJ/queuemodel.h
@@ -59,6 +59,7 @@ protected:
 
 signals:
     void queueModified(int singerId);
+    void songDroppedWithoutSinger();
 
 public slots:
     void songAdd(int songId, int singerId);

--- a/OpenKJ/updatechecker.cpp
+++ b/OpenKJ/updatechecker.cpp
@@ -1,0 +1,111 @@
+#include "updatechecker.h"
+#include <QApplication>
+#include <QDebug>
+#include <QNetworkReply>
+
+
+QString UpdateChecker::getOS() const
+{
+    return OS;
+}
+
+void UpdateChecker::setOS(const QString &value)
+{
+    OS = value;
+}
+
+QString UpdateChecker::getChannel() const
+{
+    return channel;
+}
+
+void UpdateChecker::setChannel(const QString &value)
+{
+    channel = value;
+}
+
+UpdateChecker::UpdateChecker(QObject *parent) : QObject(parent)
+{
+    OS = "unknown";
+    channel = "stable";
+    manager = new QNetworkAccessManager(this);
+    currentVer = GIT_VERSION;
+#ifdef Q_OS_WIN32
+    OS = "Win32";
+#endif
+#ifdef Q_OS_WIN64
+    OS = "Win64";
+#endif
+#ifdef Q_OS_MACOS
+    OS = "MacOS";
+#endif
+#ifdef Q_OS_LINUX
+    OS = "Linux";
+#endif
+
+#ifdef OKJ_UNSTABLE
+    channel = "unstable";
+#endif
+#ifdef OKJ_BETA
+    channel = "beta";
+#endif
+#ifdef OKJ_STABLE
+    channel = "stable";
+#endif
+//    connect(manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(onNetworkReply(QNetworkReply*)));
+}
+
+void UpdateChecker::checkForUpdates()
+{
+    qWarning() << "Requesting current version info";
+    connect(manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(onNetworkReply(QNetworkReply*)));
+    QNetworkReply *reply = manager->get(QNetworkRequest(QUrl("http://openkj.org/downloads/" + OS + "-" + channel + "-curversion.txt")));
+    while (!reply->isFinished())
+        QApplication::processEvents();
+    qWarning() << "Request completed";
+}
+
+void UpdateChecker::onNetworkReply(QNetworkReply *reply)
+{
+    qWarning() << "Received network reply";
+    if (reply->error() != QNetworkReply::NoError)
+    {
+        qWarning() << reply->errorString();
+        //output some meaningful error msg
+        return;
+    }
+    availVersion = QString(reply->readAll());
+    availVersion = availVersion.trimmed();
+    QStringList curVersionParts = currentVer.split(".");
+    QStringList availVersionParts = availVersion.split(".");
+    if (availVersionParts.size() != 3 && curVersionParts.size() != 3)
+        return;
+    int availMajor = availVersionParts.at(0).toInt();
+    int availMinor = availVersionParts.at(1).toInt();
+    int availRevis = availVersionParts.at(2).toInt();
+    int curMajor = curVersionParts.at(0).toInt();
+    int curMinor = curVersionParts.at(1).toInt();
+    int curRevis = curVersionParts.at(2).toInt();
+    if (availMajor > curMajor)
+        emit newVersionAvailable(availVersion);
+    else if (availMajor == curMajor && availMinor > curMinor)
+        emit newVersionAvailable(availVersion);
+    else if (availMajor == curMajor && availMinor == curMinor && availRevis > curRevis)
+        emit newVersionAvailable(availVersion);
+    qWarning() << "Received version: " << availVersion << " Current version: " << currentVer;
+    reply->deleteLater();
+}
+
+void UpdateChecker::downloadInstaller()
+{
+    QString url;
+    if (channel == "unstable")
+    {
+        if (OS == "Win64")
+            url = "http://openkj.org/downloads/unstable/Windows/OpenKJ-" + availVersion + "-64bit-setup.exe";
+        if (OS == "Win32")
+            url = "http://openkj.org/downloads/unstable/Windows/OpenKJ-" + availVersion + "-32bit-setup.exe";
+        if (OS == "MacOS")
+            url = "https://openkj.org/downloads/unstable/MacOS/OpenKJ-" + availVersion + "-unstable-osx-installer.dmg";
+    }
+}

--- a/OpenKJ/updatechecker.h
+++ b/OpenKJ/updatechecker.h
@@ -1,0 +1,36 @@
+#ifndef UPDATECHECKER_H
+#define UPDATECHECKER_H
+
+#include <QNetworkAccessManager>
+#include <QObject>
+
+class UpdateChecker : public QObject
+{
+    Q_OBJECT
+private:
+    QNetworkAccessManager *manager;
+    QString currentVer;
+    QString availVersion;
+    QString OS;
+    QString channel;
+public:
+    explicit UpdateChecker(QObject *parent = 0);
+    void checkForUpdates();
+
+    QString getOS() const;
+    void setOS(const QString &value);
+
+    QString getChannel() const;
+    void setChannel(const QString &value);
+
+signals:
+    void newVersionAvailable(QString version);
+
+public slots:
+
+private slots:
+    void onNetworkReply(QNetworkReply* reply);
+    void downloadInstaller();
+};
+
+#endif // UPDATECHECKER_H


### PR DESCRIPTION
* Switching back to using a custom audio fader class.

Gstreamer timed event based fader is causing too many problems.

* Fix audio volumes not being restored on program start

* Adding option to cross fade between karaoke and break music

* More fader work

* Make escape in search fields clear search (or reset it in requests dlg)

* Prevent song drops on queue w/o selected singer and warn user

* Initial work on an automatic update availability check.

* Work on update notification